### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/docs/docs/contextual-condition.md
+++ b/docs/docs/contextual-condition.md
@@ -148,7 +148,7 @@ Compares the current game time (the age of the world in game ticks) against give
 
 !!! note "Format"
 
-    See [Minecraft Wiki](https://minecraft.fandom.com/wiki/Predicate). Only supports constant value.
+    See [Minecraft Wiki](https://minecraft.wiki/w/Predicate). Only supports constant value.
 
 ??? example
 

--- a/docs/docs/general-types.md
+++ b/docs/docs/general-types.md
@@ -79,4 +79,4 @@ A BlockPredicate is a predicate of StateDefinition.
 
 ## LocationPredicate
 
-Predicate applied to location. Please refer to the [Minecraft Wiki](https://minecraft.fandom.com/wiki/Predicate).
+Predicate applied to location. Please refer to the [Minecraft Wiki](https://minecraft.wiki/w/Predicate).


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki