### PR TITLE
feat(fabric): added two tags for entities surviving in lighting bolt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,7 @@ unifiedPublishing {
         mainPublication tasks.remapJar // Declares the publicated jar
 
         curseforge {
-            token = System.getenv("CURSE_TOKEN")
+            token = System.getenv("CURSE_TOKEN") ?: ""
             id = "574650" // Required, must be a string, ID of CurseForge project
 
             relations { // Optional, Inferred from the relations above by default
@@ -189,7 +189,7 @@ unifiedPublishing {
         }
 
         modrinth {
-            token = System.getenv("MODRINTH_TOKEN")
+            token = System.getenv("MODRINTH_TOKEN") ?: ""
             id = "TdN6LxjM" // Required, must be a string, ID of Modrinth project
             displayName = project.mod_version
 

--- a/src/main/java/snownee/lychee/LycheeTags.java
+++ b/src/main/java/snownee/lychee/LycheeTags.java
@@ -5,6 +5,7 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 
@@ -22,6 +23,15 @@ public final class LycheeTags {
 	public static final TagKey<Item> BLOCK_EXPLODING_CATALYSTS = itemTag("block_exploding_catalysts");
 
 	public static final TagKey<Block> EXTEND_BOX = blockTag("extend_box");
+
+	public static final TagKey<EntityType<?>> LIGHTNING_IMMUNE = entityTag("lightning_immune");
+
+	public static final TagKey<EntityType<?>> LIGHTING_FIRE_IMMUNE = entityTag("lightning_fire_immune");
+
+
+	public static TagKey<EntityType<?>> entityTag(String path) {
+		return tag(Registries.ENTITY_TYPE, path);
+	}
 
 	public static TagKey<Item> itemTag(String path) {
 		return tag(Registries.ITEM, path);

--- a/src/main/java/snownee/lychee/mixin/EntityMixin.java
+++ b/src/main/java/snownee/lychee/mixin/EntityMixin.java
@@ -1,6 +1,10 @@
 package snownee.lychee.mixin;
 
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.LightningBolt;
+
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -8,10 +12,20 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.item.ItemEntity;
+
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import snownee.lychee.LycheeTags;
 import snownee.lychee.RecipeTypes;
 
 @Mixin(Entity.class)
-public class EntityMixin {
+public abstract class EntityMixin {
+
+	@Shadow
+	public abstract EntityType<?> getType();
+
+	@Shadow
+	public abstract void setRemainingFireTicks(int i);
 
 	@Inject(at = @At("HEAD"), method = "tick")
 	private void lychee_tick(CallbackInfo ci) {
@@ -24,4 +38,20 @@ public class EntityMixin {
 		}
 	}
 
+	@Inject(
+			at = @At(
+					value = "INVOKE",
+					target = "Lnet/minecraft/world/entity/Entity;hurt(Lnet/minecraft/world/damagesource/DamageSource;F)Z",
+					shift = At.Shift.BEFORE
+			), method = "thunderHit", cancellable = true
+	)
+	private void lychee_thunderHit_hurt(ServerLevel serverLevel, LightningBolt lightningBolt, CallbackInfo ci) {
+		if (getType().is(LycheeTags.LIGHTNING_IMMUNE)) {
+			ci.cancel();
+		}
+
+		if (getType().is(LycheeTags.LIGHTING_FIRE_IMMUNE)) {
+			setRemainingFireTicks(0);
+		}
+	}
 }

--- a/src/main/java/snownee/lychee/mixin/EntityMixin.java
+++ b/src/main/java/snownee/lychee/mixin/EntityMixin.java
@@ -25,7 +25,7 @@ public abstract class EntityMixin {
 	public abstract EntityType<?> getType();
 
 	@Shadow
-	public abstract void setRemainingFireTicks(int i);
+	public abstract void clearFire();
 
 	@Inject(at = @At("HEAD"), method = "tick")
 	private void lychee_tick(CallbackInfo ci) {
@@ -51,7 +51,7 @@ public abstract class EntityMixin {
 		}
 
 		if (getType().is(LycheeTags.LIGHTING_FIRE_IMMUNE)) {
-			setRemainingFireTicks(0);
+			clearFire();
 		}
 	}
 }

--- a/src/main/resources/data/lychee/recipes/lightning_channeling3.json
+++ b/src/main/resources/data/lychee/recipes/lightning_channeling3.json
@@ -1,0 +1,13 @@
+{
+  "type": "lychee:lightning_channeling",
+  "post": [
+    {
+      "type": "execute",
+      "command": "execute as @e[type=minecraft:pufferfish,distance=..5] at @s run summon minecraft:guardian"
+    },
+    {
+      "type": "execute",
+      "command": "execute as @e[type=minecraft:pufferfish,distance=..5] run tp ~ ~-1000 ~"
+    }
+  ]
+}

--- a/src/main/resources/data/lychee/tags/entity_types/lightning_fire_immune.json
+++ b/src/main/resources/data/lychee/tags/entity_types/lightning_fire_immune.json
@@ -1,0 +1,5 @@
+{
+  "_": "Preventing ignition for entity by lightning. Mainly for the entities summoned by lightning channelling will be ignited by lightning",
+  "replace": false,
+  "values": []
+}

--- a/src/main/resources/data/lychee/tags/entity_types/lightning_immune.json
+++ b/src/main/resources/data/lychee/tags/entity_types/lightning_immune.json
@@ -1,0 +1,7 @@
+{
+  "_": "Preventing damage from lightning for entity. For execute command on low max health mob in lightning channelling post event",
+  "replace": false,
+  "values": [
+    "fox"
+  ]
+}

--- a/src/main/resources/data/lychee/tags/entity_types/lightning_immune.json
+++ b/src/main/resources/data/lychee/tags/entity_types/lightning_immune.json
@@ -1,7 +1,5 @@
 {
   "_": "Preventing damage from lightning for entity. For execute command on low max health mob in lightning channelling post event",
   "replace": false,
-  "values": [
-    "fox"
-  ]
+  "values": []
 }

--- a/src/main/resources/data/lychee/tags/items/dispenser_placement.json
+++ b/src/main/resources/data/lychee/tags/items/dispenser_placement.json
@@ -1,0 +1,5 @@
+{
+  "replace": false,
+  "values": [
+  ]
+}

--- a/src/main/resources/data/lychee/tags/items/fire_immune.json
+++ b/src/main/resources/data/lychee/tags/items/fire_immune.json
@@ -1,0 +1,5 @@
+{
+  "replace": false,
+  "values": [
+  ]
+}


### PR DESCRIPTION
- `lychee:lightning_immune` entity tag. Preventing damage from lightning for entity. For execute command on low max health mob in lightning channelling post event
- `lychee:lightning_fire_immune` entity tag. Preventing ignition for entity by lightning. Mainly for the entities summoned by lightning channelling will be ignited by lightning
- Add placeholder for tags supported for users gonna to use them

close #60