### PR TITLE
feat: add item preservation features to AnvilCraftingRecipe

### DIFF
--- a/src/main/java/snownee/lychee/datagen/LycheeRecipeBuilder.java
+++ b/src/main/java/snownee/lychee/datagen/LycheeRecipeBuilder.java
@@ -226,6 +226,8 @@ public abstract class LycheeRecipeBuilder<T extends LycheeRecipeBuilder<T, R>, R
 		protected final int materialCost;
 		protected final ItemStack output;
 		protected final List<PostAction> assemblingActions = Lists.newArrayListWithExpectedSize(6);
+		protected boolean preserveEnchantments = true;
+		protected boolean preserveAttributes = true;
 
 		public AnvilCrafting(Ingredient left, @Nullable Ingredient right, int materialCost, int levelCost, ItemStack output) {
 			this.ingredients = right == null ? NonNullList.of(Ingredient.EMPTY, left) : NonNullList.of(Ingredient.EMPTY, left, right);
@@ -249,7 +251,7 @@ public abstract class LycheeRecipeBuilder<T extends LycheeRecipeBuilder<T, R>, R
 
 		@Override
 		public AnvilCraftingRecipe build() {
-			return new AnvilCraftingRecipe(properties(), ingredients, output, assemblingActions, levelCost, materialCost);
+			return new AnvilCraftingRecipe(properties(), ingredients, output, assemblingActions, levelCost, materialCost, preserveEnchantments, preserveAttributes);
 		}
 	}
 

--- a/src/main/java/snownee/lychee/datagen/LycheeRecipeBuilder.java
+++ b/src/main/java/snownee/lychee/datagen/LycheeRecipeBuilder.java
@@ -228,6 +228,7 @@ public abstract class LycheeRecipeBuilder<T extends LycheeRecipeBuilder<T, R>, R
 		protected final List<PostAction> assemblingActions = Lists.newArrayListWithExpectedSize(6);
 		protected boolean preserveEnchantments = true;
 		protected boolean preserveAttributes = true;
+		protected boolean preserveDurability = true;
 
 		public AnvilCrafting(Ingredient left, @Nullable Ingredient right, int materialCost, int levelCost, ItemStack output) {
 			this.ingredients = right == null ? NonNullList.of(Ingredient.EMPTY, left) : NonNullList.of(Ingredient.EMPTY, left, right);
@@ -251,7 +252,7 @@ public abstract class LycheeRecipeBuilder<T extends LycheeRecipeBuilder<T, R>, R
 
 		@Override
 		public AnvilCraftingRecipe build() {
-			return new AnvilCraftingRecipe(properties(), ingredients, output, assemblingActions, levelCost, materialCost, preserveEnchantments, preserveAttributes);
+			return new AnvilCraftingRecipe(properties(), ingredients, output, assemblingActions, levelCost, materialCost, preserveEnchantments, preserveAttributes, preserveDurability);
 		}
 	}
 

--- a/src/main/java/snownee/lychee/recipes/AnvilCraftingRecipe.java
+++ b/src/main/java/snownee/lychee/recipes/AnvilCraftingRecipe.java
@@ -5,18 +5,25 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import com.google.common.collect.Streams;
+import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 import it.unimi.dsi.fastutil.ints.IntList;
+import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.NonNullList;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.util.ExtraCodecs;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
+import net.minecraft.world.item.enchantment.ItemEnchantments;
 import net.minecraft.world.level.Level;
 import snownee.kiwi.util.codec.KCodecs;
 import snownee.lychee.RecipeSerializers;
@@ -28,7 +35,6 @@ import snownee.lychee.util.codec.LycheeCodecs;
 import snownee.lychee.util.context.LycheeContext;
 import snownee.lychee.util.context.LycheeContextKey;
 import snownee.lychee.util.json.JsonPointer;
-import snownee.lychee.util.recipe.ILycheeRecipe;
 import snownee.lychee.util.recipe.LycheeRecipe;
 import snownee.lychee.util.recipe.LycheeRecipeCommonProperties;
 import snownee.lychee.util.recipe.LycheeRecipeSerializer;
@@ -40,6 +46,8 @@ public class AnvilCraftingRecipe extends LycheeRecipe<LycheeContext> {
 	protected final int materialCost;
 	protected final ItemStack output;
 	protected final List<PostAction> assemblingActions;
+	protected final boolean preserveEnchantments;
+	protected final boolean preserveAttributes;
 
 	public AnvilCraftingRecipe(
 			LycheeRecipeCommonProperties commonProperties,
@@ -47,13 +55,17 @@ public class AnvilCraftingRecipe extends LycheeRecipe<LycheeContext> {
 			ItemStack output,
 			List<PostAction> assemblingActions,
 			int levelCost,
-			int materialCost) {
+			int materialCost,
+			boolean preserveEnchantments,
+			boolean preserveAttributes) {
 		super(commonProperties);
 		this.ingredients = ingredients;
 		this.levelCost = levelCost;
 		this.materialCost = materialCost;
 		this.output = output;
 		this.assemblingActions = assemblingActions;
+		this.preserveEnchantments = preserveEnchantments;
+		this.preserveAttributes = preserveAttributes;
 		onConstructed();
 	}
 
@@ -93,7 +105,48 @@ public class AnvilCraftingRecipe extends LycheeRecipe<LycheeContext> {
 		final var anvilContext = context.get(LycheeContextKey.ANVIL);
 		anvilContext.setLevelCost(levelCost);
 		anvilContext.setMaterialCost(materialCost);
-		context.get(LycheeContextKey.ITEM).replace(2, getResultItem(provider));
+
+		ItemStack result = getResultItem(provider);
+
+		if (preserveEnchantments) {
+			ItemStack firstInput = anvilContext.input().getFirst();
+			ItemStack secondInput = anvilContext.input().getSecond();
+
+			ItemEnchantments firstEnchantments = EnchantmentHelper.getEnchantmentsForCrafting(firstInput);
+			ItemEnchantments secondEnchantments = EnchantmentHelper.getEnchantmentsForCrafting(secondInput);
+
+			ItemEnchantments.Mutable combinedEnchantments = new ItemEnchantments.Mutable(firstEnchantments);
+
+			for (var entry : secondEnchantments.entrySet()) {
+				Holder<Enchantment> enchantment = entry.getKey();
+				int level = entry.getIntValue();
+				int existingLevel = combinedEnchantments.getLevel(enchantment);
+
+				if (existingLevel == level) {
+					level = level + 1;
+				} else {
+					level = Math.max(level, existingLevel);
+				}
+
+				if (level <= enchantment.value().getMaxLevel()) {
+					combinedEnchantments.set(enchantment, level);
+				}
+			}
+
+			EnchantmentHelper.setEnchantments(result, combinedEnchantments.toImmutable());
+		}
+
+		if (preserveAttributes) {
+			ItemStack firstInput = anvilContext.input().getFirst();
+			if (!firstInput.isEmpty()) {
+				ItemAttributeModifiers attributes = firstInput.get(DataComponents.ATTRIBUTE_MODIFIERS);
+				if (attributes != null) {
+					result.set(DataComponents.ATTRIBUTE_MODIFIERS, attributes);
+				}
+			}
+		}
+
+		context.get(LycheeContextKey.ITEM).replace(2, result);
 		final var actionContext = context.get(LycheeContextKey.ACTION);
 		actionContext.reset();
 		actionContext.jobs.addAll(assemblingActions.stream().map(it -> new Job(it, 1)).toList());
@@ -134,6 +187,14 @@ public class AnvilCraftingRecipe extends LycheeRecipe<LycheeContext> {
 		return materialCost;
 	}
 
+	public boolean preserveEnchantments() {
+		return preserveEnchantments;
+	}
+
+	public boolean preserveAttributes() {
+		return preserveAttributes;
+	}
+
 	public ItemStack output() {
 		return output;
 	}
@@ -145,36 +206,57 @@ public class AnvilCraftingRecipe extends LycheeRecipe<LycheeContext> {
 	public static class Serializer implements LycheeRecipeSerializer<AnvilCraftingRecipe> {
 		public static final MapCodec<AnvilCraftingRecipe> CODEC =
 				RecordCodecBuilder.mapCodec(instance -> instance.group(
-								LycheeRecipeCommonProperties.SIMPLE_MAP_CODEC.forGetter(ILycheeRecipe::commonProperties),
-								LycheeCodecs.sizeLimit(KCodecs.compactList(LycheeCodecs.NONEMPTY_INGREDIENT), 1, 2)
-										.xmap(NonNullListExtensions::copyOf, Function.identity())
-										.fieldOf(ITEM_IN)
-										.forGetter(AnvilCraftingRecipe::getIngredients),
-								LycheeCodecs.ITEM_STACK.fieldOf(ITEM_OUT).forGetter(AnvilCraftingRecipe::output),
-								PostAction.LIST_CODEC.optionalFieldOf("assembling", List.of()).forGetter(AnvilCraftingRecipe::assemblingActions),
-								ExtraCodecs.POSITIVE_INT.optionalFieldOf("level_cost", 1).forGetter(AnvilCraftingRecipe::levelCost),
-								ExtraCodecs.NON_NEGATIVE_INT.optionalFieldOf("material_cost", 1).forGetter(AnvilCraftingRecipe::materialCost))
-						.apply(instance, AnvilCraftingRecipe::new));
+						LycheeRecipeCommonProperties.SIMPLE_MAP_CODEC.forGetter(AnvilCraftingRecipe::commonProperties),
+						LycheeCodecs.sizeLimit(KCodecs.compactList(LycheeCodecs.NONEMPTY_INGREDIENT), 1, 2)
+								.xmap(NonNullListExtensions::copyOf, Function.identity())
+								.fieldOf(ITEM_IN)
+								.forGetter(AnvilCraftingRecipe::getIngredients),
+						LycheeCodecs.ITEM_STACK.fieldOf(ITEM_OUT).forGetter(AnvilCraftingRecipe::output),
+						PostAction.LIST_CODEC.optionalFieldOf("assembling", List.of()).forGetter(AnvilCraftingRecipe::assemblingActions),
+						ExtraCodecs.POSITIVE_INT.optionalFieldOf("level_cost", 1).forGetter(AnvilCraftingRecipe::levelCost),
+						ExtraCodecs.NON_NEGATIVE_INT.optionalFieldOf("material_cost", 1).forGetter(AnvilCraftingRecipe::materialCost),
+						Codec.BOOL.optionalFieldOf("preserve_enchantments", true).forGetter(AnvilCraftingRecipe::preserveEnchantments),
+						Codec.BOOL.optionalFieldOf("preserve_attributes", true).forGetter(AnvilCraftingRecipe::preserveAttributes)
+				).apply(instance, AnvilCraftingRecipe::new));
 
 		@Override
 		public MapCodec<AnvilCraftingRecipe> codec() {
 			return CODEC;
 		}
 
-		public static final StreamCodec<RegistryFriendlyByteBuf, AnvilCraftingRecipe> STREAM_CODEC = StreamCodec.composite(
-				LycheeRecipeCommonProperties.STREAM_CODEC,
-				AnvilCraftingRecipe::commonProperties,
-				Ingredient.CONTENTS_STREAM_CODEC.apply(ByteBufCodecs.list(2)).map(NonNullList::copyOf, Function.identity()),
-				AnvilCraftingRecipe::getIngredients,
-				ItemStack.STREAM_CODEC,
-				AnvilCraftingRecipe::output,
-				PostAction.STREAM_LIST_CODEC,
-				AnvilCraftingRecipe::assemblingActions,
-				ByteBufCodecs.VAR_INT,
-				AnvilCraftingRecipe::levelCost,
-				ByteBufCodecs.VAR_INT,
-				AnvilCraftingRecipe::materialCost,
-				AnvilCraftingRecipe::new);
+		public static final StreamCodec<RegistryFriendlyByteBuf, AnvilCraftingRecipe> STREAM_CODEC = new StreamCodec<>() {
+			@Override
+			public AnvilCraftingRecipe decode(RegistryFriendlyByteBuf buf) {
+				LycheeRecipeCommonProperties commonProperties = LycheeRecipeCommonProperties.STREAM_CODEC.decode(buf);
+				NonNullList<Ingredient> ingredients = Ingredient.CONTENTS_STREAM_CODEC
+						.apply(ByteBufCodecs.list(2))
+						.map(NonNullList::copyOf, Function.identity())
+						.decode(buf);
+				ItemStack output = ItemStack.STREAM_CODEC.decode(buf);
+				List<PostAction> assemblingActions = PostAction.STREAM_LIST_CODEC.decode(buf);
+				int levelCost = ByteBufCodecs.VAR_INT.decode(buf);
+				int materialCost = ByteBufCodecs.VAR_INT.decode(buf);
+				boolean preserveEnchantments = ByteBufCodecs.BOOL.decode(buf);
+				boolean preserveAttributes = ByteBufCodecs.BOOL.decode(buf);
+
+				return new AnvilCraftingRecipe(commonProperties, ingredients, output, assemblingActions, levelCost, materialCost, preserveEnchantments, preserveAttributes);
+			}
+
+			@Override
+			public void encode(RegistryFriendlyByteBuf buf, AnvilCraftingRecipe recipe) {
+				LycheeRecipeCommonProperties.STREAM_CODEC.encode(buf, recipe.commonProperties());
+				Ingredient.CONTENTS_STREAM_CODEC
+						.apply(ByteBufCodecs.list(2))
+						.map(NonNullList::copyOf, Function.identity())
+						.encode(buf, recipe.getIngredients());
+				ItemStack.STREAM_CODEC.encode(buf, recipe.output());
+				PostAction.STREAM_LIST_CODEC.encode(buf, recipe.assemblingActions());
+				ByteBufCodecs.VAR_INT.encode(buf, recipe.levelCost());
+				ByteBufCodecs.VAR_INT.encode(buf, recipe.materialCost());
+				ByteBufCodecs.BOOL.encode(buf, recipe.preserveEnchantments());
+				ByteBufCodecs.BOOL.encode(buf, recipe.preserveAttributes());
+			}
+		};
 
 		@Override
 		public StreamCodec<RegistryFriendlyByteBuf, AnvilCraftingRecipe> streamCodec() {

--- a/src/main/java/snownee/lychee/recipes/AnvilCraftingRecipe.java
+++ b/src/main/java/snownee/lychee/recipes/AnvilCraftingRecipe.java
@@ -48,6 +48,7 @@ public class AnvilCraftingRecipe extends LycheeRecipe<LycheeContext> {
 	protected final List<PostAction> assemblingActions;
 	protected final boolean preserveEnchantments;
 	protected final boolean preserveAttributes;
+	protected final boolean preserveDurability;
 
 	public AnvilCraftingRecipe(
 			LycheeRecipeCommonProperties commonProperties,
@@ -57,7 +58,8 @@ public class AnvilCraftingRecipe extends LycheeRecipe<LycheeContext> {
 			int levelCost,
 			int materialCost,
 			boolean preserveEnchantments,
-			boolean preserveAttributes) {
+			boolean preserveAttributes,
+			boolean preserveDurability) {
 		super(commonProperties);
 		this.ingredients = ingredients;
 		this.levelCost = levelCost;
@@ -66,6 +68,7 @@ public class AnvilCraftingRecipe extends LycheeRecipe<LycheeContext> {
 		this.assemblingActions = assemblingActions;
 		this.preserveEnchantments = preserveEnchantments;
 		this.preserveAttributes = preserveAttributes;
+		this.preserveDurability = preserveDurability;
 		onConstructed();
 	}
 
@@ -146,6 +149,15 @@ public class AnvilCraftingRecipe extends LycheeRecipe<LycheeContext> {
 			}
 		}
 
+		if (preserveDurability) {
+			ItemStack firstInput = anvilContext.input().getFirst();
+			if (firstInput.isDamageableItem() && result.isDamageableItem()) {
+				float durabilityPercentage = (float)(firstInput.getMaxDamage() - firstInput.getDamageValue()) / firstInput.getMaxDamage();
+				int newDamage = result.getMaxDamage() - Math.round(durabilityPercentage * result.getMaxDamage());
+				result.setDamageValue(Math.max(0, Math.min(newDamage, result.getMaxDamage())));
+			}
+		}
+
 		context.get(LycheeContextKey.ITEM).replace(2, result);
 		final var actionContext = context.get(LycheeContextKey.ACTION);
 		actionContext.reset();
@@ -195,6 +207,10 @@ public class AnvilCraftingRecipe extends LycheeRecipe<LycheeContext> {
 		return preserveAttributes;
 	}
 
+	public boolean preserveDurability() {
+		return preserveDurability;
+	}
+
 	public ItemStack output() {
 		return output;
 	}
@@ -216,7 +232,8 @@ public class AnvilCraftingRecipe extends LycheeRecipe<LycheeContext> {
 						ExtraCodecs.POSITIVE_INT.optionalFieldOf("level_cost", 1).forGetter(AnvilCraftingRecipe::levelCost),
 						ExtraCodecs.NON_NEGATIVE_INT.optionalFieldOf("material_cost", 1).forGetter(AnvilCraftingRecipe::materialCost),
 						Codec.BOOL.optionalFieldOf("preserve_enchantments", true).forGetter(AnvilCraftingRecipe::preserveEnchantments),
-						Codec.BOOL.optionalFieldOf("preserve_attributes", true).forGetter(AnvilCraftingRecipe::preserveAttributes)
+						Codec.BOOL.optionalFieldOf("preserve_attributes", true).forGetter(AnvilCraftingRecipe::preserveAttributes),
+						Codec.BOOL.optionalFieldOf("preserve_durability", true).forGetter(AnvilCraftingRecipe::preserveDurability)
 				).apply(instance, AnvilCraftingRecipe::new));
 
 		@Override
@@ -238,8 +255,9 @@ public class AnvilCraftingRecipe extends LycheeRecipe<LycheeContext> {
 				int materialCost = ByteBufCodecs.VAR_INT.decode(buf);
 				boolean preserveEnchantments = ByteBufCodecs.BOOL.decode(buf);
 				boolean preserveAttributes = ByteBufCodecs.BOOL.decode(buf);
+				boolean preserveDurability = ByteBufCodecs.BOOL.decode(buf);
 
-				return new AnvilCraftingRecipe(commonProperties, ingredients, output, assemblingActions, levelCost, materialCost, preserveEnchantments, preserveAttributes);
+				return new AnvilCraftingRecipe(commonProperties, ingredients, output, assemblingActions, levelCost, materialCost, preserveEnchantments, preserveAttributes, preserveDurability);
 			}
 
 			@Override
@@ -255,6 +273,7 @@ public class AnvilCraftingRecipe extends LycheeRecipe<LycheeContext> {
 				ByteBufCodecs.VAR_INT.encode(buf, recipe.materialCost());
 				ByteBufCodecs.BOOL.encode(buf, recipe.preserveEnchantments());
 				ByteBufCodecs.BOOL.encode(buf, recipe.preserveAttributes());
+				ByteBufCodecs.BOOL.encode(buf, recipe.preserveDurability());
 			}
 		};
 


### PR DESCRIPTION
## Summary  
Enhance AnvilCraftingRecipe with three preservation features: enchantments, attributes, and durability.  
  
Closes #130  
  
## Changes  
- Add preserveEnchantments, preserveAttributes, preserveDurability fields  
- Implement enchantment merging logic from both inputs  
- Copy attribute modifiers from first input item  
- Transfer durability percentage from first input to output  
- Update serializer codecs and builder pattern  
  
## Example  
```json  
{
	"type": "lychee:anvil_crafting",
	"item_in": [
		"iron_chestplate",
		"diamond"
	],
	"item_out": "diamond_chestplate",
	"level_cost": 1,
	"material_cost": 8,
	"post": "prevent_default",
	"preserve_attributes": true,
	"preserve_enchantments": true,
	"preserve_durability": true
}
```
